### PR TITLE
feat: track program completions in student journey

### DIFF
--- a/docs/student-journey.md
+++ b/docs/student-journey.md
@@ -1,0 +1,132 @@
+# Student Journey
+
+This document outlines a proposed "Student Journey" feature for tracking learning activities completed on or off the platform. The goal is to provide a timeline of courses a student has completed, along with supporting evidence and a verification workflow.
+
+## Existing Structure
+
+The application currently models users, programs, applications, and roles using Prisma. Relevant examples include:
+
+- `User` records represent platform users and are linked to roles and program applications.
+- `Program` and `ProgramApplication` handle enrollment in learning programs. A `Program` effectively acts as an internal course and `ProgramApplication.status` tracks a student's progress.
+- `Role` and `UserRole` allow assigning roles such as mentors or administrators.
+
+These models provide the foundation for associating journey entries with a user and restricting verification actions to specific roles. When a `ProgramApplication` transitions to `COMPLETED`, the system can automatically log the event in the student's journey.
+
+## Data Model
+
+Introduce new tables to capture course completions and supporting evidence:
+
+| Model | Description |
+|-------|-------------|
+| `Course` | Catalog of internal or external courses. Fields: `id`, `title`, `description`, `programId` (optional unique reference to `Program`), `sourceType` (`INTERNAL`\|`EXTERNAL`), `externalUrl`, `metadata` (JSON for arbitrary details), timestamps. |
+| `StudentCourse` | Links a `User` to a `Course` with progress details. Fields: `id`, `userId`, `courseId`, `status` (`PENDING`\|`IN_REVIEW`\|`PARTIAL`\|`VERIFIED`\|`REJECTED`), `attempt` (for repeat enrollments), `completedAt`, `notes`, `verifiedBy`, `verifiedAt`, timestamps. |
+| `CourseEvidence` | Optional supporting links or files. Fields: `id`, `studentCourseId`, `kind` (`VIDEO`\|`IMAGE`\|`DOCUMENT`\|`LINK`\|`TEXT`\|`FILE`), `url`, `description`, `metadata` (JSON), timestamps. |
+
+### Program Integration
+
+- When a `ProgramApplication` is marked `COMPLETED`, upsert a `Course` record keyed by `programId` so internal program metadata is reused instead of duplicated.
+- Automatically insert a `StudentCourse` for the user. If the student repeats the program, increment `attempt` or create a new record based on business rules.
+- Internal programs therefore appear on the timeline without extra student action, while external courses can still be logged manually.
+
+### Verification Workflow
+
+- `status` defaults to `PENDING` and transitions to `IN_REVIEW` when submitted for validation.
+- Roles granted the `VERIFY_STUDENT_COURSE` permission (e.g., mentors, admins) may update entries to `PARTIAL`, `VERIFIED`, or `REJECTED` and add `verifiedBy`/`verifiedAt` metadata.
+- Notes from both students and verifiers can be stored for context.
+
+## UI/UX
+
+1. **Student Timeline**
+   - Accessible from the dashboard.
+   - Displays `StudentCourse` entries in chronological order.
+   - Each entry shows course title, status, notes, and any attached evidence.
+
+2. **Add Course Flow**
+   - Modal or page where students search existing `Course` records or add an external course.
+   - Form collects completion date, notes, and evidence links.
+
+3. **Evidence Management**
+   - Students can attach multiple `CourseEvidence` items including videos, images, documents, or text notes.
+   - Each evidence item stores a `kind` and optional `metadata` so new formats can be introduced without schema changes.
+   - Files may be uploaded via the existing S3 module.
+
+4. **Verification Interface**
+   - Mentors/Admins view pending entries and move them through `IN_REVIEW`, `PARTIAL`, `VERIFIED`, or `REJECTED` states.
+   - Option to leave feedback or request additional evidence.
+
+## Backend/API Considerations
+
+- Extend the Prisma schema with the new models and generate migrations.
+- Provide CRUD API routes using the existing `modules/api` pattern for `Course`, `StudentCourse`, and `CourseEvidence`.
+- Apply access control using `Role`/`UserRole` and a dedicated permission (e.g., `VERIFY_STUDENT_COURSE`) to ensure only authorized mentors or admins can verify entries.
+- Trigger notifications or analytics hooks when a course is submitted or verified.
+
+## Additional Notes
+
+- The timeline can later integrate with existing `Program` data to show how external learning contributes to program prerequisites.
+- Consider using Sanity for managing a catalog of official courses while still allowing ad‑hoc external entries.
+- Maintain detailed documentation and tests for new modules, following project conventions.
+- Permissions for verification should be centralized so new roles can opt in without code changes.
+
+## Task Breakdown
+
+- **Data Model**
+  - Add `Course`, `StudentCourse`, and `CourseEvidence` models to the Prisma schema.
+  - Generate and apply database migrations.
+  - Link `ProgramApplication` completion events to `StudentCourse` creation.
+  - Support repeat enrollments via an `attempt` field and ensure `Course` upserts by `programId`.
+  - Expand enums for `StudentCourse.status` and `CourseEvidence.kind` to allow future states and evidence types.
+
+- **API Layer**
+  - Implement CRUD endpoints for `Course`, `StudentCourse`, and `CourseEvidence` using the `modules/api` pattern.
+  - Enforce role‑based authorization for verification actions via a centralized permission (e.g., `VERIFY_STUDENT_COURSE`).
+  - Wire notifications or analytics hooks on submission and verification.
+
+- **UI / UX**
+  - **Student Timeline**
+    - Display chronological `StudentCourse` entries with status, notes, and evidence.
+  - **Add Course Flow**
+    - Allow searching existing courses or adding new external ones.
+    - Collect completion date, notes, and evidence links.
+  - **Verification Interface**
+    - Provide mentors/admins a queue of pending entries.
+    - Enable status updates through `IN_REVIEW`, `PARTIAL`, `VERIFIED`, or `REJECTED` with feedback.
+
+- **Evidence Management**
+  - Support attaching multiple evidence items (videos, images, documents, text notes, files).
+  - Include a `kind` and optional `metadata` field so additional evidence formats can be introduced without migrations.
+  - Integrate with existing S3 module for file uploads.
+
+- **Documentation & Testing**
+    - Add developer docs for new models, APIs, and UI components.
+    - Create unit and integration tests covering core flows.
+
+## Implementation Checklist
+
+### Setup
+- [ ] Upgrade to the latest Next.js version if required to use Server Actions.
+- [ ] Enable Server Actions in `next.config.js`.
+
+### Data Model
+- [x] Add `Course`, `StudentCourse`, and `CourseEvidence` models in Prisma.
+- [ ] Run migrations to create the new tables.
+- [x] Hook `ProgramApplication` completion to automatically insert `StudentCourse` entries.
+
+### API (Server Actions)
+- [ ] Implement Server Actions for CRUD on courses, student courses, and evidence.
+- [ ] Enforce role-based verification permissions inside actions.
+
+### UI
+- [ ] Build a timeline page listing `StudentCourse` entries with status and evidence.
+- [ ] Provide a form to add external courses and upload evidence.
+- [ ] Create a verification dashboard for mentors/admins.
+
+### Evidence Management
+- [ ] Support attaching videos, images, documents, links, text, or files.
+- [ ] Use the existing S3 module for file uploads.
+
+### Documentation & Testing
+- [ ] Document models, actions, and UI flows.
+- [ ] Add tests for submission and verification paths.
+- [ ] Run `npm run lint`, `npm test`, and `npm run build`.
+

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -1,172 +1,249 @@
 datasource db {
-    provider = "postgresql"
-    url      = env("POSTGRES_PRISMA_URL")
+  provider = "postgresql"
+  url      = env("POSTGRES_PRISMA_URL")
 }
 
 generator client {
-    provider = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 model Account {
-    id                String  @id @default(cuid())
-    userId            String
-    type              String
-    provider          String
-    providerAccountId String
-    refresh_token     String? @db.Text
-    access_token      String? @db.Text
-    expires_at        Int?
-    token_type        String?
-    scope             String?
-    id_token          String? @db.Text
-    session_state     String?
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String? @db.Text
+  access_token      String? @db.Text
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String? @db.Text
+  session_state     String?
 
-    user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-    @@unique([provider, providerAccountId])
+  @@unique([provider, providerAccountId])
 }
 
 model Session {
-    id           String   @id @default(cuid())
-    sessionToken String   @unique
-    userId       String
-    expires      DateTime
-    user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model User {
-    id            String    @id @default(cuid())
-    name          String?
-    email         String?   @unique
-    emailVerified DateTime?
-    image         String?
+  id            String    @id @default(cuid())
+  name          String?
+  email         String?   @unique
+  emailVerified DateTime?
+  image         String?
 
-    accounts            Account[]
-    sessions            Session[]
-    programApplications ProgramApplication[]
-    files               File[]
-    userRoles           UserRole[]
-    programRoles         ProgramRole[]
+  accounts            Account[]
+  sessions            Session[]
+  programApplications ProgramApplication[]
+  files               File[]
+  userRoles           UserRole[]
+  programRoles        ProgramRole[]
+  StudentCourse       StudentCourse[]
 }
 
 model VerificationToken {
-    identifier String
-    token      String   @unique
-    expires    DateTime
+  identifier String
+  token      String   @unique
+  expires    DateTime
 
-    @@unique([identifier, token])
+  @@unique([identifier, token])
 }
 
 // Application models
 
 model Role {
-    id        String   @id @default(cuid())
-    name      String   @unique
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  id        String   @id @default(cuid())
+  name      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    userRoles UserRole[]
+  userRoles UserRole[]
 
-    @@map("Roles") // I made a mistake and had to map things for naming to be consistent (i.e. singular)
+  @@map("Roles") // I made a mistake and had to map things for naming to be consistent (i.e. singular)
 }
 
 model UserRole {
-    id        String   @id @default(cuid())
-    userId    String
-    roleId    String
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  id        String   @id @default(cuid())
+  userId    String
+  roleId    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-    role Role @relation(fields: [roleId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  role Role @relation(fields: [roleId], references: [id], onDelete: Cascade)
 
-    @@map("UserRoles") // I made a mistake and had to map things for naming to be consistent (i.e. singular)
+  @@map("UserRoles") // I made a mistake and had to map things for naming to be consistent (i.e. singular)
 }
 
 model File {
-    id        String   @id @default(cuid())
-    name      String
-    type      String
-    size      Int
-    path      String
-    ownerId   String
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  id        String   @id @default(cuid())
+  name      String
+  type      String
+  size      Int
+  path      String
+  ownerId   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    user User @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [ownerId], references: [id], onDelete: Cascade)
 }
 
 model Curriculum {
-    id          String   @id @default(cuid())
-    title       String
-    description String
-    createdAt   DateTime @default(now())
-    updatedAt   DateTime @updatedAt
+  id          String   @id @default(cuid())
+  title       String
+  description String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-    programs Program[]
+  programs Program[]
 }
 
 model Program {
-    id           String    @id @default(cuid())
-    name         String
-    description  String
-    curriculumId String
-    startDate    DateTime?
-    endDate      DateTime?
-    createdAt    DateTime  @default(now())
-    updatedAt    DateTime  @updatedAt
+  id           String    @id @default(cuid())
+  name         String
+  description  String
+  curriculumId String
+  startDate    DateTime?
+  endDate      DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
-    curriculum          Curriculum           @relation(fields: [curriculumId], references: [id])
-    programApplications ProgramApplication[]
-    programRoles         ProgramRole[]
+  curriculum          Curriculum           @relation(fields: [curriculumId], references: [id])
+  programApplications ProgramApplication[]
+  programRoles        ProgramRole[]
+  Course              Course?
 }
 
 enum ProgramRoleName {
-    INSTRUCTOR
-    TA
+  INSTRUCTOR
+  TA
 }
 
 model ProgramRole {
-    id        String          @id @default(cuid())
-    programId String
-    userId    String
-    name      ProgramRoleName
-    createdAt DateTime        @default(now())
-    updatedAt DateTime        @updatedAt
+  id        String          @id @default(cuid())
+  programId String
+  userId    String
+  name      ProgramRoleName
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
 
-    program Program @relation(fields: [programId], references: [id])
-    user    User    @relation(fields: [userId], references: [id])
+  program Program @relation(fields: [programId], references: [id])
+  user    User    @relation(fields: [userId], references: [id])
 }
 
 enum ApplicationStatus {
-    PENDING
-    APPROVED
-    REJECTED
-    AUDIT
-    COMPLETED
+  PENDING
+  APPROVED
+  REJECTED
+  AUDIT
+  COMPLETED
 }
 
 model ProgramPartner {
-    id        String   @id @default(cuid())
-    name      String
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-    programApplications ProgramApplication[]
+  programApplications ProgramApplication[]
 }
 
 model ProgramApplication {
-    id          String            @id @default(cuid())
-    programId   String?
-    userId      String
-    partnerId   String?
-    status      ApplicationStatus @default(PENDING)
-    application Json
-    createdAt   DateTime          @default(now())
-    updatedAt   DateTime          @updatedAt
-    completedAt DateTime?
+  id          String            @id @default(cuid())
+  programId   String?
+  userId      String
+  partnerId   String?
+  status      ApplicationStatus @default(PENDING)
+  application Json
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
+  completedAt DateTime?
 
-    partner ProgramPartner? @relation(fields: [partnerId], references: [id])
-    program Program?        @relation(fields: [programId], references: [id])
-    user    User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  partner ProgramPartner? @relation(fields: [partnerId], references: [id])
+  program Program?        @relation(fields: [programId], references: [id])
+  user    User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+/// Catalog entry representing an internal or external course.
+/// When linked to a `Program` the course metadata is sourced from that program
+/// so students can see internal achievements on their timeline without manual entry.
+model Course {
+  id          String           @id @default(cuid())
+  title       String
+  description String?
+  programId   String?          @unique
+  sourceType  CourseSourceType @default(EXTERNAL)
+  externalUrl String?
+  metadata    Json?
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  program        Program?        @relation(fields: [programId], references: [id])
+  studentCourses StudentCourse[]
+}
+
+/// Links a `User` to a `Course` along with progress and verification state.
+/// This drives the timeline view of a student's learning journey.
+model StudentCourse {
+  id          String              @id @default(cuid())
+  userId      String
+  courseId    String
+  status      StudentCourseStatus @default(PENDING)
+  attempt     Int                 @default(1)
+  completedAt DateTime?
+  notes       String?
+  verifiedBy  String?
+  verifiedAt  DateTime?
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+
+  user     User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  course   Course           @relation(fields: [courseId], references: [id])
+  evidence CourseEvidence[]
+}
+
+/// Optional supporting material attached to a `StudentCourse` entry such as
+/// screenshots, links, or uploaded files.
+model CourseEvidence {
+  id              String             @id @default(cuid())
+  studentCourseId String
+  kind            CourseEvidenceKind
+  url             String?
+  description     String?
+  metadata        Json?
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
+
+  studentCourse StudentCourse @relation(fields: [studentCourseId], references: [id], onDelete: Cascade)
+}
+
+enum CourseSourceType {
+  INTERNAL
+  EXTERNAL
+}
+
+enum StudentCourseStatus {
+  PENDING
+  IN_REVIEW
+  PARTIAL
+  VERIFIED
+  REJECTED
+}
+
+enum CourseEvidenceKind {
+  VIDEO
+  IMAGE
+  DOCUMENT
+  LINK
+  TEXT
+  FILE
 }

--- a/web/src/app/api/v1/[[...route]]/program-application/program-application.ts
+++ b/web/src/app/api/v1/[[...route]]/program-application/program-application.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "@/modules/auth/lib/get-server-session/get-server-session";
 import { prisma } from "@/modules/prisma/lib/prisma-client/prisma-client";
 import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
+import { logProgramCompletion } from "@/modules/student-journey/lib/log-program-completion/log-program-completion";
 import { zValidator } from "@hono/zod-validator";
 import { ApplicationStatus } from "@prisma/client";
 import { Hono } from "hono";
@@ -112,7 +113,12 @@ export const programApplicationHandler = new Hono()
         data: {
           ...body.programApplication,
         },
+        include: { program: true },
       });
+
+      if (application.status === ApplicationStatus.COMPLETED) {
+        await logProgramCompletion(application);
+      }
 
       return c.json(application, 200);
     },

--- a/web/src/modules/student-journey/lib/log-program-completion/log-program-completion.ts
+++ b/web/src/modules/student-journey/lib/log-program-completion/log-program-completion.ts
@@ -1,0 +1,49 @@
+/**
+ * Records completion of an internal program as a `StudentCourse` entry.
+ *
+ * When a `ProgramApplication` is marked `COMPLETED`, internal programs should
+ * surface automatically on the student's timeline. This helper ensures the
+ * corresponding `Course` exists (keyed to the `Program`) and then creates a
+ * `StudentCourse` row for the user. Each run increments the attempt count so
+ * repeat enrollments remain distinct.
+ */
+import {
+  CourseSourceType,
+  Program,
+  ProgramApplication,
+  StudentCourseStatus,
+} from "@prisma/client";
+import { prisma } from "@/modules/prisma/lib/prisma-client/prisma-client";
+
+export async function logProgramCompletion(
+  application: ProgramApplication & { program?: Program | null },
+) {
+  if (!application.programId) return;
+
+  // Reuse or create a course linked to the program to avoid duplicated metadata.
+  const course = await prisma.course.upsert({
+    where: { programId: application.programId },
+    update: {},
+    create: {
+      programId: application.programId,
+      title: application.program?.name ?? "Program",
+      description: application.program?.description ?? undefined,
+      sourceType: CourseSourceType.INTERNAL,
+    },
+  });
+
+  // Determine how many times the student has completed this course.
+  const attemptCount = await prisma.studentCourse.count({
+    where: { userId: application.userId, courseId: course.id },
+  });
+
+  await prisma.studentCourse.create({
+    data: {
+      userId: application.userId,
+      courseId: course.id,
+      status: StudentCourseStatus.VERIFIED,
+      attempt: attemptCount + 1,
+      completedAt: application.completedAt ?? new Date(),
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add Course, StudentCourse, and CourseEvidence models with enums for source type, status, and evidence kinds
- log internal program completions as StudentCourse entries for automatic timeline updates
- mark data-model progress in Student Journey documentation

## Testing
- `npm test` (fails: Cannot find module '@auth/prisma-adapter')
- `npm run lint`
- `npm run build` (fails: page only in development mode; P1001 Can't reach database at `localhost:5432`)


------
https://chatgpt.com/codex/tasks/task_e_68a720c109b8832cacc40e9ab122a475