### PR TITLE
feat: add admin blog management

### DIFF
--- a/web/docs/blogging.md
+++ b/web/docs/blogging.md
@@ -4,7 +4,9 @@ This document outlines how the blog feature is wired into the platform.
 
 ## Posts
 
-- Admin users compose posts at `/admin/blog/new` using a Markdown editor.
+- Admin users compose posts at `/admin/blog/new` using a Markdown editor and can
+  revisit existing entries from `/admin/blog` where posts may be edited or
+  deleted.
 - Content is stored in Postgres via Prisma using the `BlogPost` model. Each post
   records the author, title, slug and raw Markdown content.
 

--- a/web/src/app/(admin)/admin/blog/[slug]/edit/actions/update-post.ts
+++ b/web/src/app/(admin)/admin/blog/[slug]/edit/actions/update-post.ts
@@ -1,0 +1,27 @@
+"use server";
+
+/**
+ * update-post.ts
+ * ----------------
+ * Server action for saving edits to an existing blog post. The action checks
+ * that the caller is an administrator before delegating to the update helper.
+ */
+
+import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
+import { updateBlogPost } from "@/modules/blog/lib/update-post/update-post";
+import { revalidatePath } from "next/cache";
+
+export async function updatePost(data: {
+  slug: string;
+  title: string;
+  content: string;
+}) {
+  await checkAdminPermissions();
+  if (!data.slug || !data.title || !data.content) {
+    throw new Error("slug, title and content are required");
+  }
+  await updateBlogPost(data.slug, data.title, data.content);
+  revalidatePath(`/blog/${data.slug}`);
+  revalidatePath("/blog");
+  revalidatePath("/admin/blog");
+}

--- a/web/src/app/(admin)/admin/blog/[slug]/edit/edit-post-client.tsx
+++ b/web/src/app/(admin)/admin/blog/[slug]/edit/edit-post-client.tsx
@@ -1,0 +1,56 @@
+/**
+ * edit-post-client.tsx
+ * ---------------------
+ * Client component powering the blog post editor used for updates. It mirrors
+ * the new post editor but initializes state from the existing post and invokes
+ * the updatePost server action when saving.
+ */
+
+"use client";
+
+import dynamic from "next/dynamic";
+import { useState, useTransition } from "react";
+import { Stack, Button, TextField } from "@mui/material";
+import { updatePost } from "./actions/update-post";
+
+const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
+
+export function EditPostClient({
+  initialTitle,
+  initialContent,
+  slug,
+}: {
+  initialTitle: string;
+  initialContent: string;
+  slug: string;
+}) {
+  const [title, setTitle] = useState(initialTitle);
+  const [value, setValue] = useState<string | undefined>(initialContent);
+  const [isPending, startTransition] = useTransition();
+
+  function save() {
+    if (!title || !value) return;
+    startTransition(async () => {
+      await updatePost({ slug, title, content: value });
+    });
+  }
+
+  return (
+    <Stack spacing={2}>
+      <TextField
+        label="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        fullWidth
+      />
+      <MDEditor value={value} onChange={setValue} previewOptions={{}} />
+      <Button
+        variant="contained"
+        onClick={save}
+        disabled={!title || !value || isPending}
+      >
+        {isPending ? "Saving..." : "Save"}
+      </Button>
+    </Stack>
+  );
+}

--- a/web/src/app/(admin)/admin/blog/[slug]/edit/page.tsx
+++ b/web/src/app/(admin)/admin/blog/[slug]/edit/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * page.tsx (admin blog edit)
+ * --------------------------
+ * Server component used to edit an existing blog post. It verifies access
+ * rights, loads the post by slug and renders the client-side editor.
+ */
+
+import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
+import { getPost } from "@/modules/blog/lib/get-post/get-post";
+import { EditPostClient } from "./edit-post-client";
+import { notFound } from "next/navigation";
+
+export default async function EditPostPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  await checkAdminPermissions();
+  const post = await getPost(params.slug);
+  if (!post) {
+    notFound();
+  }
+  return (
+    <EditPostClient
+      slug={post.slug}
+      initialTitle={post.title}
+      initialContent={post.content}
+    />
+  );
+}

--- a/web/src/app/(admin)/admin/blog/actions/delete-post.ts
+++ b/web/src/app/(admin)/admin/blog/actions/delete-post.ts
@@ -1,0 +1,24 @@
+"use server";
+
+/**
+ * delete-post.ts
+ * ----------------
+ * Server action used by the admin blog list to remove a post. The action simply
+ * ensures the caller has administrative privileges before delegating deletion to
+ * the database helper.
+ */
+
+import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
+import { deleteBlogPost } from "@/modules/blog/lib/delete-post/delete-post";
+import { revalidatePath } from "next/cache";
+
+export async function deletePost(slug: string) {
+  await checkAdminPermissions();
+  if (!slug) {
+    throw new Error("slug required");
+  }
+  await deleteBlogPost(slug);
+  revalidatePath(`/blog/${slug}`);
+  revalidatePath("/blog");
+  revalidatePath("/admin/blog");
+}

--- a/web/src/app/(admin)/admin/blog/new/actions/create-post.ts
+++ b/web/src/app/(admin)/admin/blog/new/actions/create-post.ts
@@ -11,6 +11,7 @@
 import { getServerSession } from "@/modules/auth/lib/get-server-session/get-server-session";
 import { createBlogPost } from "@/modules/blog/lib/create-post/create-post";
 import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
+import { revalidatePath } from "next/cache";
 
 export async function createPost(data: { title: string; content: string }) {
   await checkAdminPermissions();
@@ -21,5 +22,8 @@ export async function createPost(data: { title: string; content: string }) {
   if (!data.title || !data.content) {
     throw new Error("Title and content are required");
   }
-  return createBlogPost(data.title, data.content, session.user.id);
+  const slug = await createBlogPost(data.title, data.content, session.user.id);
+  revalidatePath("/blog");
+  revalidatePath("/admin/blog");
+  return slug;
 }

--- a/web/src/app/(admin)/admin/blog/page.tsx
+++ b/web/src/app/(admin)/admin/blog/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * page.tsx (admin blog index)
+ * ---------------------------
+ * Server component that lists all blog posts for administrators. It performs the
+ * necessary permission check and then hands rendering over to the PostsClient
+ * component for interactivity.
+ */
+
+import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
+import { getPosts } from "@/modules/blog/lib/get-posts/get-posts";
+import { PostsClient } from "./posts-client";
+import { Stack, Button } from "@mui/material";
+import Link from "next/link";
+
+export default async function AdminBlogIndex() {
+  await checkAdminPermissions();
+  const posts = await getPosts();
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2}>
+        <Link href="/admin/blog/new">
+          <Button variant="contained">New Post</Button>
+        </Link>
+      </Stack>
+      <PostsClient posts={posts} />
+    </Stack>
+  );
+}

--- a/web/src/app/(admin)/admin/blog/posts-client.tsx
+++ b/web/src/app/(admin)/admin/blog/posts-client.tsx
@@ -1,0 +1,49 @@
+/**
+ * posts-client.tsx
+ * -----------------
+ * Client component responsible for rendering the list of existing posts and
+ * wiring up delete actions. Editing is handled via standard links to the
+ * dedicated edit page. Keeping this component client-side keeps the server
+ * component lean and allows interactive deletion without full reloads.
+ */
+
+"use client";
+
+import { useTransition } from "react";
+import { Button, Stack } from "@mui/material";
+import Link from "next/link";
+import { deletePost } from "./actions/delete-post";
+
+interface PostSummary {
+  title: string;
+  slug: string;
+}
+
+export function PostsClient({ posts }: { posts: PostSummary[] }) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete(slug: string) {
+    startTransition(async () => {
+      await deletePost(slug);
+    });
+  }
+
+  return (
+    <Stack spacing={2}>
+      {posts.map((p) => (
+        <Stack key={p.slug} direction="row" spacing={2} alignItems="center">
+          <Link href={`/admin/blog/${p.slug}/edit`}>{p.title}</Link>
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => handleDelete(p.slug)}
+            disabled={isPending}
+          >
+            Delete
+          </Button>
+        </Stack>
+      ))}
+      {posts.length === 0 && <div>No posts yet.</div>}
+    </Stack>
+  );
+}

--- a/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
+++ b/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
@@ -27,6 +27,7 @@ import {
   PiCalendar,
   PiTable,
   PiUserDuotone,
+  PiNotePencilDuotone,
 } from "react-icons/pi";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import "dayjs/locale/en";
@@ -199,6 +200,11 @@ export function MainAdminLayout({
                 icon={<PiCalendar fontSize={25} />}
                 primary="Programs"
                 href="/admin/program"
+              />
+              <NavLink
+                icon={<PiNotePencilDuotone fontSize={25} />}
+                primary="New Post"
+                href="/admin/blog/new"
               />
             </List>
             <Box sx={{ flexGrow: 1 }} />

--- a/web/src/modules/blog/lib/delete-post/delete-post.ts
+++ b/web/src/modules/blog/lib/delete-post/delete-post.ts
@@ -1,0 +1,15 @@
+/**
+ * delete-post.ts
+ * ----------------
+ * Thin wrapper around Prisma's delete call for blog posts. Keeping this logic in
+ * a dedicated module lets server actions remain small and focused.
+ */
+
+import { prisma } from "@/modules/prisma/lib/prisma-client/prisma-client";
+
+/**
+ * Permanently removes a blog post identified by its slug.
+ */
+export async function deleteBlogPost(slug: string) {
+  await prisma.blogPost.delete({ where: { slug } });
+}

--- a/web/src/modules/blog/lib/update-post/update-post.ts
+++ b/web/src/modules/blog/lib/update-post/update-post.ts
@@ -1,0 +1,23 @@
+/**
+ * update-post.ts
+ * ----------------
+ * Small helper that updates an existing blog post. The slug is treated as the
+ * immutable identifier for the post, so changing the title does not rewrite the
+ * slug. This avoids breaking existing links.
+ */
+
+import { prisma } from "@/modules/prisma/lib/prisma-client/prisma-client";
+
+/**
+ * Updates title and content of a blog post.
+ */
+export async function updateBlogPost(
+  slug: string,
+  title: string,
+  content: string,
+) {
+  await prisma.blogPost.update({
+    where: { slug },
+    data: { title, content },
+  });
+}


### PR DESCRIPTION
## Summary
- link "New Post" in admin navigation
- add admin blog index with edit/delete actions
- support editing existing posts via server actions

## Testing
- `npm test` *(fails: Cannot find module '@auth/prisma-adapter')*
- `npm run lint`
- `npm run build` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7af57b80832ca6072d5723a29977