### PR TITLE
feat: add blog post table migration

### DIFF
--- a/web/prisma/migrations/20240722160000_add_blog_post/migration.sql
+++ b/web/prisma/migrations/20240722160000_add_blog_post/migration.sql
@@ -1,0 +1,20 @@
+-- Adds the BlogPost table to persist user-authored articles
+-- This migration introduces a simple schema for content management.
+-- CreateTable
+CREATE TABLE "BlogPost" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BlogPost_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BlogPost_slug_key" ON "BlogPost"("slug");
+
+-- AddForeignKey
+ALTER TABLE "BlogPost" ADD CONSTRAINT "BlogPost_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- add migration to create the `BlogPost` table for saving posts

## Testing
- `npm test` (fails: Cannot find module '@auth/prisma-adapter')
- `npm run lint`
- `npm run build` (fails: Can't reach database server at `localhost:5432`)

------
https://chatgpt.com/codex/tasks/task_e_68ad925c2f28832ca8a64e346ea07296