### PR TITLE
feat: add admin blog list and polish blog pages

### DIFF
--- a/web/docs/blogging.md
+++ b/web/docs/blogging.md
@@ -7,6 +7,8 @@ This document outlines how the blog feature is wired into the platform.
 - Admin users compose posts at `/admin/blog/new` using a Markdown editor and can
   revisit existing entries from `/admin/blog` where posts may be edited or
   deleted.
+- The admin sidebar links directly to `/admin/blog`, which presents all posts in
+  a sortable table for quick management.
 - Content is stored in Postgres via Prisma using the `BlogPost` model. Each post
   records the author, title, slug and raw Markdown content.
 

--- a/web/src/app/(admin)/admin/blog/page.tsx
+++ b/web/src/app/(admin)/admin/blog/page.tsx
@@ -9,14 +9,22 @@
 import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
 import { getPosts } from "@/modules/blog/lib/get-posts/get-posts";
 import { PostsClient } from "./posts-client";
-import { Stack, Button } from "@mui/material";
+import { Stack, Button, Typography } from "@mui/material";
 import Link from "next/link";
 
 export default async function AdminBlogIndex() {
   await checkAdminPermissions();
-  const posts = await getPosts();
+  const posts = (await getPosts()).map((p) => ({
+    id: p.id,
+    slug: p.slug,
+    title: p.title,
+    createdAt: p.createdAt.toISOString(),
+  }));
   return (
     <Stack spacing={2}>
+      <Typography variant="h4" color="white">
+        Blog Posts
+      </Typography>
       <Stack direction="row" spacing={2}>
         <Link href="/admin/blog/new">
           <Button variant="contained">New Post</Button>

--- a/web/src/app/(admin)/admin/blog/posts-client.tsx
+++ b/web/src/app/(admin)/admin/blog/posts-client.tsx
@@ -1,22 +1,24 @@
+"use client";
+
 /**
  * posts-client.tsx
  * -----------------
- * Client component responsible for rendering the list of existing posts and
- * wiring up delete actions. Editing is handled via standard links to the
- * dedicated edit page. Keeping this component client-side keeps the server
- * component lean and allows interactive deletion without full reloads.
+ * Renders the blog post list inside the admin area using MUI's DataGrid. Each
+ * row exposes edit and delete actions so administrators can manage the catalog
+ * without full page reloads.
  */
 
-"use client";
-
 import { useTransition } from "react";
-import { Button, Stack } from "@mui/material";
+import { Button } from "@mui/material";
+import { DataGrid, type GridColDef } from "@mui/x-data-grid";
 import Link from "next/link";
 import { deletePost } from "./actions/delete-post";
 
 interface PostSummary {
-  title: string;
+  id: string;
   slug: string;
+  title: string;
+  createdAt: string;
 }
 
 export function PostsClient({ posts }: { posts: PostSummary[] }) {
@@ -28,22 +30,47 @@ export function PostsClient({ posts }: { posts: PostSummary[] }) {
     });
   }
 
+  const columns: GridColDef[] = [
+    {
+      field: "edit",
+      headerName: "",
+      width: 80,
+      renderCell: (params) => (
+        <Link href={`/admin/blog/${params.row.slug}/edit`}>Edit</Link>
+      ),
+    },
+    { field: "title", headerName: "Title", flex: 1 },
+    { field: "slug", headerName: "Slug", flex: 1 },
+    {
+      field: "createdAt",
+      headerName: "Created",
+      width: 150,
+      valueGetter: (params) =>
+        new Date((params as any).row.createdAt as string).toLocaleDateString(),
+    },
+    {
+      field: "delete",
+      headerName: "",
+      width: 100,
+      renderCell: (params) => (
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={() => handleDelete(params.row.slug)}
+          disabled={isPending}
+        >
+          Delete
+        </Button>
+      ),
+    },
+  ];
+
   return (
-    <Stack spacing={2}>
-      {posts.map((p) => (
-        <Stack key={p.slug} direction="row" spacing={2} alignItems="center">
-          <Link href={`/admin/blog/${p.slug}/edit`}>{p.title}</Link>
-          <Button
-            variant="outlined"
-            color="error"
-            onClick={() => handleDelete(p.slug)}
-            disabled={isPending}
-          >
-            Delete
-          </Button>
-        </Stack>
-      ))}
-      {posts.length === 0 && <div>No posts yet.</div>}
-    </Stack>
+    <DataGrid
+      autoHeight
+      disableRowSelectionOnClick
+      rows={posts}
+      columns={columns}
+    />
   );
 }

--- a/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
+++ b/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+/**
+ * main-admin-layout.tsx
+ * ---------------------
+ * Provides the chrome for all admin pages including navigation, drawer
+ * behavior and authentication gate. The drawer now links to the blog post list
+ * so administrators can browse and manage existing entries alongside creating
+ * new ones.
+ */
+
 import { Link } from "@/components/link/link";
 import { useLoginRedirect } from "@/modules/auth/hooks/use-login-redirect/use-login-redirect";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
@@ -200,6 +209,11 @@ export function MainAdminLayout({
                 icon={<PiCalendar fontSize={25} />}
                 primary="Programs"
                 href="/admin/program"
+              />
+              <NavLink
+                icon={<PiTable fontSize={25} />}
+                primary="Blog Posts"
+                href="/admin/blog"
               />
               <NavLink
                 icon={<PiNotePencilDuotone fontSize={25} />}

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -9,6 +9,7 @@
 
 import { getPost } from "@/modules/blog/lib/get-post/get-post";
 import Markdown from "react-markdown";
+import { Container, Stack, Typography } from "@mui/material";
 
 export const dynamic = "force-dynamic";
 
@@ -22,9 +23,13 @@ export default async function BlogPost({ params }: Params) {
     return <p>Post not found</p>;
   }
   return (
-    <article>
-      <h1>{post.title}</h1>
-      <Markdown>{post.content}</Markdown>
-    </article>
+    <Container sx={{ py: 4 }}>
+      <Stack spacing={2} alignItems="center" sx={{ color: "white" }}>
+        <Typography variant="h3" color="orange.main" align="center">
+          {post.title}
+        </Typography>
+        <Markdown>{post.content}</Markdown>
+      </Stack>
+    </Container>
   );
 }

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -9,18 +9,37 @@
 
 import Link from "next/link";
 import { getPosts } from "@/modules/blog/lib/get-posts/get-posts";
+import { Container, Stack, Typography } from "@mui/material";
 
 export const dynamic = "force-dynamic";
 
 export default async function BlogIndex() {
   const posts = await getPosts();
   return (
-    <ul>
-      {posts.map((p) => (
-        <li key={p.slug}>
-          <Link href={`/blog/${p.slug}`}>{p.title}</Link>
-        </li>
-      ))}
-    </ul>
+    <Container sx={{ py: 4 }}>
+      <Stack spacing={3} alignItems="center">
+        <Typography variant="h3" color="orange.main">
+          Blog
+        </Typography>
+        <Stack spacing={4} sx={{ width: "100%" }}>
+          {posts.map((p) => (
+            <Link
+              key={p.slug}
+              href={`/blog/${p.slug}`}
+              style={{ textDecoration: "none" }}
+            >
+              <Stack spacing={1}>
+                <Typography variant="h5" color="white">
+                  {p.title}
+                </Typography>
+                <Typography color="white" variant="body2">
+                  {p.content.slice(0, 120)}...
+                </Typography>
+              </Stack>
+            </Link>
+          ))}
+        </Stack>
+      </Stack>
+    </Container>
   );
 }


### PR DESCRIPTION
## Summary
- add sidebar link and DataGrid-driven management for blog posts
- restyle public blog pages to match home aesthetic
- document blogging workflow

## Testing
- `npm test` *(fails: Cannot find module '@auth/prisma-adapter')*
- `npm run lint`
- `npm run build` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68adad72cdd0832c9c4c49062b82aa8f