### PR TITLE
Improve admin blog management tools

### DIFF
--- a/web/docs/blogging.md
+++ b/web/docs/blogging.md
@@ -5,10 +5,18 @@ This document outlines how the blog feature is wired into the platform.
 ## Posts
 
 - Admin users compose posts at `/admin/blog/new` using a Markdown editor and can
-  revisit existing entries from `/admin/blog` where posts may be edited or
-  deleted.
+  revisit existing entries from `/admin/blog` where posts may be edited,
+  deleted, or opened publicly.
 - Content is stored in Postgres via Prisma using the `BlogPost` model. Each post
   records the author, title, slug and raw Markdown content.
+
+## Admin Interface
+
+- The `/admin/blog` dashboard presents posts inside a sortable table so
+  administrators can quickly review publication dates and jump to view, edit or
+  delete actions without leaving the screen.
+- Deletions refresh the table automatically thanks to server actions that
+  revalidate the list.
 
 ## Images
 

--- a/web/src/app/(admin)/admin/blog/page.tsx
+++ b/web/src/app/(admin)/admin/blog/page.tsx
@@ -1,28 +1,45 @@
 /**
  * page.tsx (admin blog index)
  * ---------------------------
- * Server component that lists all blog posts for administrators. It performs the
- * necessary permission check and then hands rendering over to the PostsClient
- * component for interactivity.
+ * Server component that lists all blog posts for administrators. It performs
+ * the mandatory permission check, loads the posts from the database and
+ * serializes the relevant metadata so the client-side data grid can present a
+ * full management interface (view, edit and delete).
  */
 
 import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
 import { getPosts } from "@/modules/blog/lib/get-posts/get-posts";
-import { PostsClient } from "./posts-client";
-import { Stack, Button } from "@mui/material";
-import Link from "next/link";
+import { PostsClient, type AdminPostRow } from "./posts-client";
+import { Stack, Button, Typography } from "@mui/material";
+import NextLink from "next/link";
 
 export default async function AdminBlogIndex() {
   await checkAdminPermissions();
   const posts = await getPosts();
+  const serializedPosts: AdminPostRow[] = posts.map((post) => ({
+    id: post.id,
+    title: post.title,
+    slug: post.slug,
+    createdAt: post.createdAt.toISOString(),
+    updatedAt: post.updatedAt.toISOString(),
+  }));
+
   return (
-    <Stack spacing={2}>
-      <Stack direction="row" spacing={2}>
-        <Link href="/admin/blog/new">
-          <Button variant="contained">New Post</Button>
-        </Link>
+    <Stack spacing={3}>
+      <Stack
+        direction="row"
+        spacing={2}
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Typography variant="h4" component="h1">
+          Blog Posts
+        </Typography>
+        <Button variant="contained" component={NextLink} href="/admin/blog/new">
+          New Post
+        </Button>
       </Stack>
-      <PostsClient posts={posts} />
+      <PostsClient posts={serializedPosts} />
     </Stack>
   );
 }

--- a/web/src/app/(admin)/admin/blog/posts-client.tsx
+++ b/web/src/app/(admin)/admin/blog/posts-client.tsx
@@ -1,49 +1,177 @@
 /**
  * posts-client.tsx
  * -----------------
- * Client component responsible for rendering the list of existing posts and
- * wiring up delete actions. Editing is handled via standard links to the
- * dedicated edit page. Keeping this component client-side keeps the server
- * component lean and allows interactive deletion without full reloads.
+ * Client component rendering the administrative blog table. It presents the
+ * posts inside a Material UI data grid so administrators can quickly scan the
+ * published catalog, jump to the public article, open the editor or remove the
+ * post altogether. The component handles deletion optimistically while asking
+ * Next.js to refresh server data so the grid always reflects the latest
+ * database state.
  */
 
 "use client";
 
-import { useTransition } from "react";
+import { useCallback, useMemo, useState, useTransition } from "react";
+import NextLink from "next/link";
 import { Button, Stack } from "@mui/material";
-import Link from "next/link";
+import {
+  DataGrid,
+  type GridColDef,
+  type GridRenderCellParams,
+} from "@mui/x-data-grid";
+import { useRouter } from "next/navigation";
 import { deletePost } from "./actions/delete-post";
 
-interface PostSummary {
-  title: string;
-  slug: string;
+/**
+ * Intl formatter reused across column definitions so the date rendering stays
+ * consistent and avoids recreating the formatter on every cell render.
+ */
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatDate(value: unknown) {
+  if (!value) {
+    return "";
+  }
+  try {
+    return dateTimeFormatter.format(new Date(value as string));
+  } catch (error) {
+    console.error("Failed to format blog post date", error);
+    return String(value);
+  }
 }
 
-export function PostsClient({ posts }: { posts: PostSummary[] }) {
+export interface AdminPostRow {
+  id: string;
+  title: string;
+  slug: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function PostsClient({ posts }: { posts: AdminPostRow[] }) {
+  const router = useRouter();
+  const [pendingSlug, setPendingSlug] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  function handleDelete(slug: string) {
-    startTransition(async () => {
-      await deletePost(slug);
-    });
-  }
+  const handleDelete = useCallback(
+    (slug: string) => {
+      if (!slug) {
+        return;
+      }
+      setPendingSlug(slug);
+      startTransition(async () => {
+        try {
+          await deletePost(slug);
+          router.refresh();
+        } catch (error) {
+          console.error("Failed to delete blog post", error);
+        } finally {
+          setPendingSlug(null);
+        }
+      });
+    },
+    [router],
+  );
+
+  const columns = useMemo<Array<GridColDef<AdminPostRow>>>(
+    () => [
+      {
+        field: "title",
+        headerName: "Title",
+        flex: 1,
+        minWidth: 220,
+      },
+      {
+        field: "slug",
+        headerName: "Slug",
+        flex: 1,
+        minWidth: 200,
+      },
+      {
+        field: "createdAt",
+        headerName: "Published",
+        flex: 1,
+        minWidth: 200,
+        valueFormatter: ({ value }) => formatDate(value),
+      },
+      {
+        field: "updatedAt",
+        headerName: "Last Updated",
+        flex: 1,
+        minWidth: 200,
+        valueFormatter: ({ value }) => formatDate(value),
+      },
+      {
+        field: "actions",
+        headerName: "Actions",
+        sortable: false,
+        filterable: false,
+        minWidth: 280,
+        align: "right",
+        headerAlign: "right",
+        renderCell: (params: GridRenderCellParams<AdminPostRow>) => (
+          <Stack
+            direction="row"
+            spacing={1}
+            justifyContent="flex-end"
+            sx={{ width: "100%" }}
+          >
+            <Button
+              component={NextLink}
+              href={`/blog/${params.row.slug}`}
+              size="small"
+              target="_blank"
+              rel="noopener"
+            >
+              View
+            </Button>
+            <Button
+              component={NextLink}
+              href={`/admin/blog/${params.row.slug}/edit`}
+              variant="outlined"
+              size="small"
+            >
+              Edit
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              size="small"
+              onClick={() => handleDelete(params.row.slug)}
+              disabled={isPending && pendingSlug === params.row.slug}
+            >
+              Delete
+            </Button>
+          </Stack>
+        ),
+      },
+    ],
+    [handleDelete, isPending, pendingSlug],
+  );
 
   return (
-    <Stack spacing={2}>
-      {posts.map((p) => (
-        <Stack key={p.slug} direction="row" spacing={2} alignItems="center">
-          <Link href={`/admin/blog/${p.slug}/edit`}>{p.title}</Link>
-          <Button
-            variant="outlined"
-            color="error"
-            onClick={() => handleDelete(p.slug)}
-            disabled={isPending}
-          >
-            Delete
-          </Button>
-        </Stack>
-      ))}
-      {posts.length === 0 && <div>No posts yet.</div>}
-    </Stack>
+    <DataGrid
+      autoHeight
+      disableRowSelectionOnClick
+      rows={posts}
+      columns={columns}
+      initialState={{
+        sorting: {
+          sortModel: [{ field: "createdAt", sort: "desc" }],
+        },
+      }}
+      sx={{
+        backgroundColor: "background.paper",
+        borderRadius: 2,
+        border: "none",
+        boxShadow: 1,
+        "& .MuiDataGrid-columnHeaders": {
+          backgroundColor: "grey.100",
+        },
+      }}
+    />
   );
 }

--- a/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
+++ b/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
@@ -28,6 +28,7 @@ import {
   PiTable,
   PiUserDuotone,
   PiNotePencilDuotone,
+  PiNewspaperDuotone,
 } from "react-icons/pi";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import "dayjs/locale/en";
@@ -200,6 +201,11 @@ export function MainAdminLayout({
                 icon={<PiCalendar fontSize={25} />}
                 primary="Programs"
                 href="/admin/program"
+              />
+              <NavLink
+                icon={<PiNewspaperDuotone fontSize={25} />}
+                primary="Blog Posts"
+                href="/admin/blog"
               />
               <NavLink
                 icon={<PiNotePencilDuotone fontSize={25} />}

--- a/web/src/modules/blog/lib/get-posts/get-posts.ts
+++ b/web/src/modules/blog/lib/get-posts/get-posts.ts
@@ -14,6 +14,7 @@ export interface BlogPost {
   title: string;
   content: string;
   createdAt: Date;
+  updatedAt: Date;
 }
 
 export async function getPosts(): Promise<BlogPost[]> {


### PR DESCRIPTION
## Summary
- replace the admin blog index with a sortable data grid that supports viewing, editing, and deleting posts
- expose the blog list from the admin navigation and serialize post metadata for the client table
- document the refreshed admin interface and extend the blog post query typings

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef0459504832caeff2e57720988fa