### PR TITLE
style: refresh public blog experience

### DIFF
--- a/web/src/app/(admin)/admin/blog/page.tsx
+++ b/web/src/app/(admin)/admin/blog/page.tsx
@@ -10,8 +10,9 @@
 import { checkAdminPermissions } from "@/modules/roles/lib/check-admin-permissions/check-admin-permissions";
 import { getPosts } from "@/modules/blog/lib/get-posts/get-posts";
 import { PostsClient, type AdminPostRow } from "./posts-client";
-import { Stack, Button, Typography } from "@mui/material";
+import { Box, Button, Container, Stack, Typography } from "@mui/material";
 import NextLink from "next/link";
+import { customColors, getShadow } from "@/modules/mui/theme/constants";
 
 export default async function AdminBlogIndex() {
   await checkAdminPermissions();
@@ -25,21 +26,55 @@ export default async function AdminBlogIndex() {
   }));
 
   return (
-    <Stack spacing={3}>
-      <Stack
-        direction="row"
-        spacing={2}
-        alignItems="center"
-        justifyContent="space-between"
-      >
-        <Typography variant="h4" component="h1">
-          Blog Posts
-        </Typography>
-        <Button variant="contained" component={NextLink} href="/admin/blog/new">
-          New Post
-        </Button>
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Stack spacing={4}>
+        <Box
+          sx={{
+            backgroundImage: `linear-gradient(135deg, ${customColors.lessDark.main}, ${customColors.orange.main})`,
+            borderRadius: 4,
+            boxShadow: getShadow("lg"),
+            color: "common.white",
+            px: { xs: 3, md: 5 },
+            py: { xs: 4, md: 5 },
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            alignItems: { xs: "flex-start", md: "center" },
+            justifyContent: "space-between",
+            gap: { xs: 3, md: 4 },
+          }}
+        >
+          <Stack spacing={1} sx={{ maxWidth: { md: "60%" } }}>
+            <Typography variant="h3" component="h1" color="inherit">
+              Blog Posts
+            </Typography>
+            <Typography variant="body1" color="rgba(255,255,255,0.85)">
+              Curate the stories that welcome visitors to Tembo Tech Ventures.
+              Publish updates, refine messaging, and keep our community engaged
+              with the latest wins.
+            </Typography>
+          </Stack>
+          <Button
+            variant="contained"
+            component={NextLink}
+            href="/admin/blog/new"
+            sx={{
+              alignSelf: { xs: "stretch", md: "center" },
+              backgroundColor: "common.white",
+              color: customColors.dark.main,
+              fontWeight: 600,
+              px: { xs: 3, md: 4 },
+              py: 1.5,
+              borderRadius: 999,
+              "&:hover": {
+                backgroundColor: "grey.100",
+              },
+            }}
+          >
+            New Post
+          </Button>
+        </Box>
+        <PostsClient posts={serializedPosts} />
       </Stack>
-      <PostsClient posts={serializedPosts} />
-    </Stack>
+    </Container>
   );
 }

--- a/web/src/app/(admin)/admin/blog/posts-client.tsx
+++ b/web/src/app/(admin)/admin/blog/posts-client.tsx
@@ -21,6 +21,18 @@ import {
 } from "@mui/x-data-grid";
 import { useRouter } from "next/navigation";
 import { deletePost } from "./actions/delete-post";
+import { customColors, getShadow } from "@/modules/mui/theme/constants";
+
+/**
+ * Precomputed style helpers keep the gradient-heavy aesthetic consistent while
+ * satisfying Prettier's preferred line lengths.
+ */
+const GRID_BACKGROUND_GRADIENT =
+  "linear-gradient(180deg, rgba(255,255,255,0.97), rgba(255,255,255,0.9))";
+const GRID_HEADER_GRADIENT = `linear-gradient(135deg, ${customColors.dark.main}, ${customColors.lessDark.main})`;
+const GRID_STRIPED_ROW_COLOR = "rgba(44,105,100,0.05)";
+const GRID_PAGINATION_SELECTOR =
+  "& .MuiTablePagination-root, & .MuiTablePagination-selectLabel, & .MuiTablePagination-displayedRows";
 
 /**
  * Intl formatter reused across column definitions so the date rendering stays
@@ -125,23 +137,41 @@ export function PostsClient({ posts }: { posts: AdminPostRow[] }) {
               size="small"
               target="_blank"
               rel="noopener"
+              sx={{
+                fontWeight: 600,
+                color: customColors.dark.main,
+                backgroundColor: "rgba(255,255,255,0.8)",
+                border: "1px solid rgba(1,61,57,0.2)",
+                "&:hover": {
+                  backgroundColor: "rgba(255,255,255,1)",
+                },
+              }}
             >
               View
             </Button>
             <Button
               component={NextLink}
               href={`/admin/blog/${params.row.slug}/edit`}
-              variant="outlined"
+              variant="contained"
               size="small"
+              sx={{
+                fontWeight: 600,
+                backgroundColor: customColors.lessDark.main,
+                color: "common.white",
+                "&:hover": {
+                  backgroundColor: customColors.dark.main,
+                },
+              }}
             >
               Edit
             </Button>
             <Button
-              variant="outlined"
+              variant="contained"
               color="error"
               size="small"
               onClick={() => handleDelete(params.row.slug)}
               disabled={isPending && pendingSlug === params.row.slug}
+              sx={{ fontWeight: 600 }}
             >
               Delete
             </Button>
@@ -164,12 +194,28 @@ export function PostsClient({ posts }: { posts: AdminPostRow[] }) {
         },
       }}
       sx={{
-        backgroundColor: "background.paper",
-        borderRadius: 2,
-        border: "none",
-        boxShadow: 1,
+        backgroundImage: GRID_BACKGROUND_GRADIENT,
+        borderRadius: 4,
+        border: "1px solid rgba(255,255,255,0.2)",
+        boxShadow: getShadow("md"),
+        overflow: "hidden",
         "& .MuiDataGrid-columnHeaders": {
-          backgroundColor: "grey.100",
+          backgroundImage: GRID_HEADER_GRADIENT,
+          color: "common.white",
+          borderBottom: "1px solid rgba(255,255,255,0.2)",
+        },
+        "& .MuiDataGrid-columnHeader, & .MuiDataGrid-cell": {
+          borderColor: "rgba(1,61,57,0.08)",
+        },
+        "& .MuiDataGrid-row:nth-of-type(odd)": {
+          backgroundColor: GRID_STRIPED_ROW_COLOR,
+        },
+        "& .MuiDataGrid-footerContainer": {
+          backgroundColor: "rgba(255,255,255,0.85)",
+          borderTop: "1px solid rgba(1,61,57,0.12)",
+        },
+        [GRID_PAGINATION_SELECTOR]: {
+          color: "text.primary",
         },
       }}
     />

--- a/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
+++ b/web/src/app/(admin)/components/main-admin-layout/main-admin-layout.tsx
@@ -27,7 +27,6 @@ import {
   PiCalendar,
   PiTable,
   PiUserDuotone,
-  PiNotePencilDuotone,
   PiNewspaperDuotone,
 } from "react-icons/pi";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -206,11 +205,6 @@ export function MainAdminLayout({
                 icon={<PiNewspaperDuotone fontSize={25} />}
                 primary="Blog Posts"
                 href="/admin/blog"
-              />
-              <NavLink
-                icon={<PiNotePencilDuotone fontSize={25} />}
-                primary="New Post"
-                href="/admin/blog/new"
               />
             </List>
             <Box sx={{ flexGrow: 1 }} />

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -1,13 +1,25 @@
 /**
  * BlogPost
  * --------
- * Displays a single blog entry. Similar to the index page, this component is
- * flagged `force-dynamic` so that the database query only occurs at request
- * time. Without this, a static export would attempt to resolve the dynamic
- * route at build time and fail if the database is unreachable.
+ * Renders the detailed view for a single blog entry using the same gradient
+ * language and typography scale as the marketing homepage. The component stays
+ * server-rendered to keep Prisma queries on the backend while providing rich
+ * presentation for the markdown content.
+ *
+ * Key behaviours:
+ * - Formats the publication timestamp for humans using `Intl.DateTimeFormat`.
+ * - Provides bespoke Markdown component overrides so headings, paragraphs, and
+ *   lists inherit the site's typography system.
+ * - Wraps the layout in a gradient shell with generous spacing for comfortable
+ *   reading on both mobile and desktop breakpoints.
  */
 
+import { Link } from "@/components/link/link";
 import { getPost } from "@/modules/blog/lib/get-post/get-post";
+import { customColors, getShadow } from "@/modules/mui/theme/constants";
+import { Box, Container, Stack, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+import type { Components } from "react-markdown";
 import Markdown from "react-markdown";
 
 export const dynamic = "force-dynamic";
@@ -16,15 +28,261 @@ interface Params {
   params: { slug: string };
 }
 
+const PUBLISH_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "long",
+});
+
+const markdownComponents: Components = {
+  h2: ({ children }) => (
+    <Typography
+      component="h2"
+      variant="h4"
+      fontWeight={700}
+      color={customColors.orange.main}
+      sx={{ mt: 6, mb: 2 }}
+    >
+      {children}
+    </Typography>
+  ),
+  h3: ({ children }) => (
+    <Typography
+      component="h3"
+      variant="h5"
+      fontWeight={600}
+      color="white"
+      sx={{ mt: 4, mb: 1.5 }}
+    >
+      {children}
+    </Typography>
+  ),
+  p: ({ children }) => (
+    <Typography
+      variant="body1"
+      paragraph
+      sx={{ color: "rgba(255,255,255,0.85)", lineHeight: 1.7 }}
+    >
+      {children}
+    </Typography>
+  ),
+  strong: ({ children }) => (
+    <Box component="strong" sx={{ fontWeight: 700, color: "white" }}>
+      {children}
+    </Box>
+  ),
+  em: ({ children }) => (
+    <Box
+      component="em"
+      sx={{ fontStyle: "italic", color: "rgba(255,255,255,0.85)" }}
+    >
+      {children}
+    </Box>
+  ),
+  ul: ({ children }) => (
+    <Box
+      component="ul"
+      sx={{
+        pl: 3,
+        my: 2,
+        color: "rgba(255,255,255,0.85)",
+        listStyle: "disc",
+      }}
+    >
+      {children}
+    </Box>
+  ),
+  ol: ({ children }) => (
+    <Box
+      component="ol"
+      sx={{
+        pl: 3,
+        my: 2,
+        color: "rgba(255,255,255,0.85)",
+        listStyle: "decimal",
+      }}
+    >
+      {children}
+    </Box>
+  ),
+  li: ({ children }) => (
+    <Typography
+      component="li"
+      variant="body1"
+      sx={{ mb: 1, color: "rgba(255,255,255,0.85)" }}
+    >
+      {children}
+    </Typography>
+  ),
+  code: (props) => {
+    const { inline = false, children } = props as {
+      inline?: boolean;
+      children: ReactNode;
+    };
+
+    return (
+      <Box
+        component="code"
+        sx={{
+          display: inline ? "inline" : "block",
+          backgroundColor: "rgba(0,0,0,0.35)",
+          borderRadius: 2,
+          px: 1.5,
+          py: inline ? 0.5 : 1,
+          fontFamily: "'Fira Code', 'Courier New', monospace",
+          fontSize: "0.95rem",
+          color: customColors.orange.main,
+          my: inline ? 0 : 2,
+          whiteSpace: inline ? "pre-wrap" : "pre",
+        }}
+      >
+        {children}
+      </Box>
+    );
+  },
+  a: ({ href, children }) => (
+    <Link
+      href={href ?? "#"}
+      muiLinkProps={{
+        underline: "hover",
+        sx: { color: customColors.orange.main, fontWeight: 600 },
+      }}
+    >
+      {children}
+    </Link>
+  ),
+  blockquote: ({ children }) => (
+    <Box
+      component="blockquote"
+      sx={{
+        borderLeft: `4px solid ${customColors.orange.main}`,
+        pl: 3,
+        my: 3,
+        color: "rgba(255,255,255,0.85)",
+        fontStyle: "italic",
+      }}
+    >
+      {children}
+    </Box>
+  ),
+};
+
 export default async function BlogPost({ params }: Params) {
   const post = await getPost(params.slug);
+
   if (!post) {
-    return <p>Post not found</p>;
+    return (
+      <Stack
+        component="main"
+        sx={{
+          minHeight: "100vh",
+          backgroundColor: customColors.dark.main,
+          backgroundImage: `linear-gradient(180deg, ${customColors.dark.main}, ${customColors.lessDark.main})`,
+          py: { xs: 6, md: 10 },
+        }}
+      >
+        <Container maxWidth="sm">
+          <Box
+            sx={{
+              borderRadius: 4,
+              p: { xs: 4, md: 5 },
+              textAlign: "center",
+              backgroundColor: "rgba(1, 61, 57, 0.75)",
+              boxShadow: getShadow("md"),
+              color: "white",
+            }}
+          >
+            <Typography variant="h4" fontWeight={700} gutterBottom>
+              We couldn’t find that story.
+            </Typography>
+            <Typography
+              variant="body1"
+              sx={{ color: "rgba(255,255,255,0.8)" }}
+              gutterBottom
+            >
+              The post may have been moved or removed. Explore the latest
+              insights from our team instead.
+            </Typography>
+            <Link
+              href="/blog"
+              muiLinkProps={{
+                underline: "none",
+                sx: {
+                  display: "inline-block",
+                  mt: 3,
+                  px: 3,
+                  py: 1.5,
+                  borderRadius: 999,
+                  backgroundImage: `linear-gradient(135deg, ${customColors.lessDark.main}, ${customColors.orange.main})`,
+                  color: "white",
+                  fontWeight: 600,
+                },
+              }}
+            >
+              Browse all posts
+            </Link>
+          </Box>
+        </Container>
+      </Stack>
+    );
   }
+
+  const publishedOn = PUBLISH_DATE_FORMATTER.format(post.createdAt);
+
   return (
-    <article>
-      <h1>{post.title}</h1>
-      <Markdown>{post.content}</Markdown>
-    </article>
+    <Stack
+      component="main"
+      sx={{
+        minHeight: "100vh",
+        backgroundColor: customColors.dark.main,
+        backgroundImage: `linear-gradient(180deg, ${customColors.dark.main}, ${customColors.lessDark.main})`,
+        py: { xs: 6, md: 10 },
+      }}
+    >
+      <Container maxWidth="md">
+        <Link
+          href="/blog"
+          muiLinkProps={{
+            underline: "hover",
+            sx: {
+              color: "rgba(255,255,255,0.75)",
+              fontWeight: 600,
+              letterSpacing: 0.5,
+            },
+          }}
+        >
+          ← Back to all posts
+        </Link>
+        <Box
+          sx={{
+            mt: 3,
+            backgroundImage: `linear-gradient(135deg, ${customColors.lessDark.main}, ${customColors.orange.main})`,
+            borderRadius: 5,
+            p: { xs: 4, md: 5 },
+            boxShadow: getShadow("lg"),
+            color: "white",
+          }}
+        >
+          <Typography component="h1" variant="h3" fontWeight={700} gutterBottom>
+            {post.title}
+          </Typography>
+          <Typography
+            variant="subtitle1"
+            sx={{ color: "rgba(255,255,255,0.85)" }}
+          >
+            {publishedOn}
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            mt: 4,
+            borderRadius: 4,
+            backgroundColor: "rgba(1, 61, 57, 0.85)",
+            boxShadow: getShadow("md"),
+            p: { xs: 3, md: 5 },
+          }}
+        >
+          <Markdown components={markdownComponents}>{post.content}</Markdown>
+        </Box>
+      </Container>
+    </Stack>
   );
 }

--- a/web/src/app/blog/components/blog-post-card/blog-post-card.tsx
+++ b/web/src/app/blog/components/blog-post-card/blog-post-card.tsx
@@ -1,0 +1,106 @@
+/**
+ * BlogPostCard
+ * ------------
+ * Presentational helper that renders a teaser for a single blog entry. The
+ * card embraces Tembo's gradient surfaces and rounded edges while remaining
+ * lightweight enough to render server-side inside the blog index route.
+ *
+ * Responsibilities:
+ * - Format the publication date into a human-readable string using
+ *   `Intl.DateTimeFormat` so localisation can be extended easily.
+ * - Generate a concise excerpt from the markdown body to entice readers without
+ *   overwhelming the list view.
+ * - Wrap the entire surface in the shared `<Link>` component so hover and focus
+ *   states match other navigational affordances on the site.
+ */
+
+import { Link } from "@/components/link/link";
+import type { BlogPost } from "@/modules/blog/lib/get-posts/get-posts";
+import { customColors, getShadow } from "@/modules/mui/theme/constants";
+import { Stack, Typography } from "@mui/material";
+
+const PUBLISH_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "long",
+});
+
+const EXCERPT_MAX_LENGTH = 180;
+
+/**
+ * Creates a short teaser paragraph by stripping common markdown syntax and
+ * trimming the copy to a fixed length. Keeping the logic co-located with the
+ * card keeps the parent index component focused on layout concerns.
+ */
+function createExcerpt(markdown: string): string {
+  const withoutMarkdown = markdown
+    .replace(/[#*_`>~\-]+/g, " ")
+    .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (withoutMarkdown.length <= EXCERPT_MAX_LENGTH) {
+    return withoutMarkdown;
+  }
+  return `${withoutMarkdown.slice(0, EXCERPT_MAX_LENGTH).trimEnd()}…`;
+}
+
+interface BlogPostCardProps {
+  post: BlogPost;
+}
+
+export function BlogPostCard({ post }: BlogPostCardProps) {
+  const publishedOn = PUBLISH_DATE_FORMATTER.format(post.createdAt);
+  const excerpt = createExcerpt(post.content);
+
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      muiLinkProps={{
+        underline: "none",
+        sx: { display: "block", borderRadius: 4 },
+      }}
+    >
+      <Stack
+        spacing={2}
+        sx={{
+          height: "100%",
+          borderRadius: 4,
+          backgroundImage: `linear-gradient(150deg, rgba(255,255,255,0.08), rgba(242,141,104,0.25))`,
+          backgroundColor: "rgba(1, 61, 57, 0.75)",
+          color: "white",
+          p: 4,
+          boxShadow: getShadow("md"),
+          transition: "transform 150ms ease, box-shadow 150ms ease",
+          "&:hover": {
+            transform: "translateY(-6px)",
+            boxShadow: getShadow("lg"),
+          },
+          "&:focus-within": {
+            transform: "translateY(-6px)",
+            boxShadow: getShadow("lg"),
+          },
+        }}
+      >
+        <Typography variant="overline" sx={{ color: "rgba(255,255,255,0.75)" }}>
+          {publishedOn}
+        </Typography>
+        <Typography variant="h5" component="h2" fontWeight={600}>
+          {post.title}
+        </Typography>
+        <Typography variant="body1" sx={{ color: "rgba(255,255,255,0.82)" }}>
+          {excerpt}
+        </Typography>
+        <Typography
+          variant="button"
+          sx={{
+            mt: "auto",
+            alignSelf: "flex-start",
+            color: customColors.orange.main,
+            fontWeight: 600,
+            letterSpacing: 1,
+          }}
+        >
+          Read story →
+        </Typography>
+      </Stack>
+    </Link>
+  );
+}

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -1,26 +1,96 @@
 /**
  * BlogIndex
  * ---------
- * Server component that lists published blog posts. The page is marked as
- * `force-dynamic` so Next.js renders it at request time instead of during the
- * build. This avoids build failures when the database is unavailable (such as
- * in CI) while still serving fresh content in production.
+ * Public-facing blog landing page that mirrors the expressive gradients and
+ * rounded surfaces used across the marketing site. The component keeps the
+ * server-rendered data fetching behaviour (`force-dynamic`) while layering a
+ * visually rich hero banner and a responsive grid of teaser cards.
+ *
+ * Implementation notes:
+ * - The surrounding `<Stack>` paints the familiar dark-to-teal gradient so the
+ *   blog feels cohesive with the rest of the brand experiences.
+ * - A hero callout introduces the blog with warm tones and subtle shadowing to
+ *   echo the homepage hero.
+ * - Individual posts are rendered via `BlogPostCard`, which is responsible for
+ *   truncating copy and formatting dates so the list remains scannable.
+ * - Empty states are handled gracefully with a styled panel that still honours
+ *   the theme palette.
  */
 
-import Link from "next/link";
+import { BlogPostCard } from "./components/blog-post-card/blog-post-card";
 import { getPosts } from "@/modules/blog/lib/get-posts/get-posts";
+import { customColors, getShadow } from "@/modules/mui/theme/constants";
+import { Box, Container, Grid, Stack, Typography } from "@mui/material";
 
 export const dynamic = "force-dynamic";
 
 export default async function BlogIndex() {
   const posts = await getPosts();
+
   return (
-    <ul>
-      {posts.map((p) => (
-        <li key={p.slug}>
-          <Link href={`/blog/${p.slug}`}>{p.title}</Link>
-        </li>
-      ))}
-    </ul>
+    <Stack
+      component="main"
+      sx={{
+        minHeight: "100vh",
+        backgroundColor: customColors.dark.main,
+        backgroundImage: `linear-gradient(180deg, ${customColors.dark.main}, ${customColors.lessDark.main})`,
+        py: { xs: 6, md: 10 },
+      }}
+    >
+      <Container maxWidth="lg">
+        <Box
+          sx={{
+            backgroundImage: `linear-gradient(135deg, ${customColors.lessDark.main}, ${customColors.orange.main})`,
+            borderRadius: 6,
+            p: { xs: 4, md: 6 },
+            boxShadow: getShadow("lg"),
+            color: "white",
+            textAlign: { xs: "center", md: "left" },
+          }}
+        >
+          <Typography component="h1" variant="h3" fontWeight={700} gutterBottom>
+            Insights from Tembo Tech Ventures
+          </Typography>
+          <Typography
+            variant="h6"
+            sx={{ maxWidth: 640, mx: { xs: "auto", md: 0 } }}
+          >
+            Explore founder stories, product learnings, and the principles that
+            guide how we build technology with purpose.
+          </Typography>
+        </Box>
+
+        {posts.length > 0 ? (
+          <Grid container spacing={{ xs: 3, md: 4 }} mt={{ xs: 4, md: 6 }}>
+            {posts.map((post) => (
+              <Grid key={post.slug} item xs={12} md={6}>
+                <BlogPostCard post={post} />
+              </Grid>
+            ))}
+          </Grid>
+        ) : (
+          <Box
+            sx={{
+              mt: 6,
+              borderRadius: 4,
+              backgroundColor: "rgba(1, 61, 57, 0.65)",
+              border: `1px solid rgba(242, 141, 104, 0.35)`,
+              p: { xs: 4, md: 6 },
+              color: "white",
+              textAlign: "center",
+              boxShadow: getShadow("md"),
+            }}
+          >
+            <Typography variant="h5" fontWeight={600} gutterBottom>
+              Posts are on their way
+            </Typography>
+            <Typography variant="body1" color="rgba(255, 255, 255, 0.75)">
+              Check back soon for fresh thinking from the Tembo Tech Ventures
+              team.
+            </Typography>
+          </Box>
+        )}
+      </Container>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the public blog index with a branded gradient hero and responsive teaser grid
- add a reusable blog post card component to format dates and excerpts consistently
- redesign individual blog posts with markdown-aware typography, gradients, and a polished empty state

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe0c22b60832c84cbf46d24ba51b5