### PR TITLE
Refine blog pages to reuse shared card styling

### DIFF
--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -1,22 +1,23 @@
 /**
  * BlogPost
  * --------
- * Renders the detailed view for a single blog entry using the same gradient
- * language and typography scale as the marketing homepage. The component stays
- * server-rendered to keep Prisma queries on the backend while providing rich
- * presentation for the markdown content.
+ * Server-rendered detail view for a single blog entry. The layout intentionally
+ * mirrors the homepage card treatment for the header while letting the article
+ * body sit directly on the page background. This keeps the writing front-and-
+ * centre without heavy gradients or drop shadows.
  *
  * Key behaviours:
  * - Formats the publication timestamp for humans using `Intl.DateTimeFormat`.
  * - Provides bespoke Markdown component overrides so headings, paragraphs, and
  *   lists inherit the site's typography system.
- * - Wraps the layout in a gradient shell with generous spacing for comfortable
- *   reading on both mobile and desktop breakpoints.
+ * - Shares the same `<Card>` surface from the homepage for the title/date block
+ *   while keeping the article content container-free.
  */
 
+import { Card } from "@/components/card/card";
 import { Link } from "@/components/link/link";
 import { getPost } from "@/modules/blog/lib/get-post/get-post";
-import { customColors, getShadow } from "@/modules/mui/theme/constants";
+import { customColors } from "@/modules/mui/theme/constants";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import type { ReactNode } from "react";
 import type { Components } from "react-markdown";
@@ -49,7 +50,7 @@ const markdownComponents: Components = {
       component="h3"
       variant="h5"
       fontWeight={600}
-      color="white"
+      color="text.primary"
       sx={{ mt: 4, mb: 1.5 }}
     >
       {children}
@@ -59,21 +60,18 @@ const markdownComponents: Components = {
     <Typography
       variant="body1"
       paragraph
-      sx={{ color: "rgba(255,255,255,0.85)", lineHeight: 1.7 }}
+      sx={{ color: "text.secondary", lineHeight: 1.7 }}
     >
       {children}
     </Typography>
   ),
   strong: ({ children }) => (
-    <Box component="strong" sx={{ fontWeight: 700, color: "white" }}>
+    <Box component="strong" sx={{ fontWeight: 700, color: "text.primary" }}>
       {children}
     </Box>
   ),
   em: ({ children }) => (
-    <Box
-      component="em"
-      sx={{ fontStyle: "italic", color: "rgba(255,255,255,0.85)" }}
-    >
+    <Box component="em" sx={{ fontStyle: "italic", color: "text.secondary" }}>
       {children}
     </Box>
   ),
@@ -83,7 +81,7 @@ const markdownComponents: Components = {
       sx={{
         pl: 3,
         my: 2,
-        color: "rgba(255,255,255,0.85)",
+        color: "text.secondary",
         listStyle: "disc",
       }}
     >
@@ -96,7 +94,7 @@ const markdownComponents: Components = {
       sx={{
         pl: 3,
         my: 2,
-        color: "rgba(255,255,255,0.85)",
+        color: "text.secondary",
         listStyle: "decimal",
       }}
     >
@@ -107,7 +105,7 @@ const markdownComponents: Components = {
     <Typography
       component="li"
       variant="body1"
-      sx={{ mb: 1, color: "rgba(255,255,255,0.85)" }}
+      sx={{ mb: 1, color: "text.secondary" }}
     >
       {children}
     </Typography>
@@ -123,7 +121,7 @@ const markdownComponents: Components = {
         component="code"
         sx={{
           display: inline ? "inline" : "block",
-          backgroundColor: "rgba(0,0,0,0.35)",
+          backgroundColor: "rgba(255,255,255,0.05)",
           borderRadius: 2,
           px: 1.5,
           py: inline ? 0.5 : 1,
@@ -156,7 +154,7 @@ const markdownComponents: Components = {
         borderLeft: `4px solid ${customColors.orange.main}`,
         pl: 3,
         my: 3,
-        color: "rgba(255,255,255,0.85)",
+        color: "text.secondary",
         fontStyle: "italic",
       }}
     >
@@ -174,52 +172,29 @@ export default async function BlogPost({ params }: Params) {
         component="main"
         sx={{
           minHeight: "100vh",
-          backgroundColor: customColors.dark.main,
-          backgroundImage: `linear-gradient(180deg, ${customColors.dark.main}, ${customColors.lessDark.main})`,
+          bgcolor: "background.default",
           py: { xs: 6, md: 10 },
         }}
       >
         <Container maxWidth="sm">
-          <Box
-            sx={{
-              borderRadius: 4,
-              p: { xs: 4, md: 5 },
-              textAlign: "center",
-              backgroundColor: "rgba(1, 61, 57, 0.75)",
-              boxShadow: getShadow("md"),
-              color: "white",
-            }}
-          >
+          <Card component="section" style={{ textAlign: "center" }}>
             <Typography variant="h4" fontWeight={700} gutterBottom>
               We couldn’t find that story.
             </Typography>
-            <Typography
-              variant="body1"
-              sx={{ color: "rgba(255,255,255,0.8)" }}
-              gutterBottom
-            >
+            <Typography variant="body1" color="text.secondary" gutterBottom>
               The post may have been moved or removed. Explore the latest
               insights from our team instead.
             </Typography>
             <Link
               href="/blog"
               muiLinkProps={{
-                underline: "none",
-                sx: {
-                  display: "inline-block",
-                  mt: 3,
-                  px: 3,
-                  py: 1.5,
-                  borderRadius: 999,
-                  backgroundImage: `linear-gradient(135deg, ${customColors.lessDark.main}, ${customColors.orange.main})`,
-                  color: "white",
-                  fontWeight: 600,
-                },
+                underline: "hover",
+                sx: { color: "primary.main", fontWeight: 600 },
               }}
             >
               Browse all posts
             </Link>
-          </Box>
+          </Card>
         </Container>
       </Stack>
     );
@@ -232,8 +207,7 @@ export default async function BlogPost({ params }: Params) {
       component="main"
       sx={{
         minHeight: "100vh",
-        backgroundColor: customColors.dark.main,
-        backgroundImage: `linear-gradient(180deg, ${customColors.dark.main}, ${customColors.lessDark.main})`,
+        bgcolor: "background.default",
         py: { xs: 6, md: 10 },
       }}
     >
@@ -243,7 +217,7 @@ export default async function BlogPost({ params }: Params) {
           muiLinkProps={{
             underline: "hover",
             sx: {
-              color: "rgba(255,255,255,0.75)",
+              color: "text.secondary",
               fontWeight: 600,
               letterSpacing: 0.5,
             },
@@ -251,35 +225,22 @@ export default async function BlogPost({ params }: Params) {
         >
           ← Back to all posts
         </Link>
-        <Box
-          sx={{
-            mt: 3,
-            backgroundImage: `linear-gradient(135deg, ${customColors.lessDark.main}, ${customColors.orange.main})`,
-            borderRadius: 5,
-            p: { xs: 4, md: 5 },
-            boxShadow: getShadow("lg"),
-            color: "white",
-          }}
-        >
-          <Typography component="h1" variant="h3" fontWeight={700} gutterBottom>
-            {post.title}
-          </Typography>
-          <Typography
-            variant="subtitle1"
-            sx={{ color: "rgba(255,255,255,0.85)" }}
-          >
-            {publishedOn}
-          </Typography>
+        <Box mt={3}>
+          <Card component="header">
+            <Typography
+              component="h1"
+              variant="h3"
+              fontWeight={700}
+              gutterBottom
+            >
+              {post.title}
+            </Typography>
+            <Typography variant="subtitle1" color="text.secondary">
+              {publishedOn}
+            </Typography>
+          </Card>
         </Box>
-        <Box
-          sx={{
-            mt: 4,
-            borderRadius: 4,
-            backgroundColor: "rgba(1, 61, 57, 0.85)",
-            boxShadow: getShadow("md"),
-            p: { xs: 3, md: 5 },
-          }}
-        >
+        <Box mt={4}>
           <Markdown components={markdownComponents}>{post.content}</Markdown>
         </Box>
       </Container>

--- a/web/src/app/blog/components/blog-post-card/blog-post-card.tsx
+++ b/web/src/app/blog/components/blog-post-card/blog-post-card.tsx
@@ -2,8 +2,9 @@
  * BlogPostCard
  * ------------
  * Presentational helper that renders a teaser for a single blog entry. The
- * card embraces Tembo's gradient surfaces and rounded edges while remaining
- * lightweight enough to render server-side inside the blog index route.
+ * component now leans on the shared `<Card>` surface that already ships on the
+ * homepage, which keeps the visual language consistent while avoiding bespoke
+ * gradient styling.
  *
  * Responsibilities:
  * - Format the publication date into a human-readable string using
@@ -14,9 +15,9 @@
  *   states match other navigational affordances on the site.
  */
 
+import { Card } from "@/components/card/card";
 import { Link } from "@/components/link/link";
 import type { BlogPost } from "@/modules/blog/lib/get-posts/get-posts";
-import { customColors, getShadow } from "@/modules/mui/theme/constants";
 import { Stack, Typography } from "@mui/material";
 
 const PUBLISH_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
@@ -55,52 +56,34 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
       href={`/blog/${post.slug}`}
       muiLinkProps={{
         underline: "none",
-        sx: { display: "block", borderRadius: 4 },
+        sx: { display: "block", height: "100%" },
       }}
     >
-      <Stack
-        spacing={2}
-        sx={{
-          height: "100%",
-          borderRadius: 4,
-          backgroundImage: `linear-gradient(150deg, rgba(255,255,255,0.08), rgba(242,141,104,0.25))`,
-          backgroundColor: "rgba(1, 61, 57, 0.75)",
-          color: "white",
-          p: 4,
-          boxShadow: getShadow("md"),
-          transition: "transform 150ms ease, box-shadow 150ms ease",
-          "&:hover": {
-            transform: "translateY(-6px)",
-            boxShadow: getShadow("lg"),
-          },
-          "&:focus-within": {
-            transform: "translateY(-6px)",
-            boxShadow: getShadow("lg"),
-          },
-        }}
-      >
-        <Typography variant="overline" sx={{ color: "rgba(255,255,255,0.75)" }}>
-          {publishedOn}
-        </Typography>
-        <Typography variant="h5" component="h2" fontWeight={600}>
-          {post.title}
-        </Typography>
-        <Typography variant="body1" sx={{ color: "rgba(255,255,255,0.82)" }}>
-          {excerpt}
-        </Typography>
-        <Typography
-          variant="button"
-          sx={{
-            mt: "auto",
-            alignSelf: "flex-start",
-            color: customColors.orange.main,
-            fontWeight: 600,
-            letterSpacing: 1,
-          }}
-        >
-          Read story →
-        </Typography>
-      </Stack>
+      <Card component="article" style={{ height: "100%" }}>
+        <Stack spacing={2} sx={{ height: "100%" }}>
+          <Typography variant="overline" color="text.secondary">
+            {publishedOn}
+          </Typography>
+          <Typography variant="h5" component="h2" fontWeight={600}>
+            {post.title}
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            {excerpt}
+          </Typography>
+          <Typography
+            variant="button"
+            sx={{
+              mt: "auto",
+              alignSelf: "flex-start",
+              color: "primary.main",
+              fontWeight: 600,
+              letterSpacing: 1,
+            }}
+          >
+            Read story →
+          </Typography>
+        </Stack>
+      </Card>
     </Link>
   );
 }

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -1,26 +1,26 @@
 /**
  * BlogIndex
  * ---------
- * Public-facing blog landing page that mirrors the expressive gradients and
- * rounded surfaces used across the marketing site. The component keeps the
- * server-rendered data fetching behaviour (`force-dynamic`) while layering a
- * visually rich hero banner and a responsive grid of teaser cards.
+ * Server-rendered landing page for the public blog experience. The goal of the
+ * latest iteration is to reuse the same card treatment that appears on the
+ * homepage while removing the heavy gradient shells that previously framed the
+ * layout. Doing so keeps the focus on the writing rather than the chrome
+ * surrounding it.
  *
  * Implementation notes:
- * - The surrounding `<Stack>` paints the familiar dark-to-teal gradient so the
- *   blog feels cohesive with the rest of the brand experiences.
- * - A hero callout introduces the blog with warm tones and subtle shadowing to
- *   echo the homepage hero.
- * - Individual posts are rendered via `BlogPostCard`, which is responsible for
- *   truncating copy and formatting dates so the list remains scannable.
- * - Empty states are handled gracefully with a styled panel that still honours
- *   the theme palette.
+ * - The hero copy is rendered directly on the page background without an
+ *   additional container so that the typography stands alone, per the design
+ *   direction.
+ * - Each post preview reuses the shared `<Card>` component from the homepage to
+ *   maintain a consistent surface treatment.
+ * - Empty states still communicate clearly, but now rely on the same card
+ *   styling to avoid bespoke gradient shells.
  */
 
 import { BlogPostCard } from "./components/blog-post-card/blog-post-card";
+import { Card } from "@/components/card/card";
 import { getPosts } from "@/modules/blog/lib/get-posts/get-posts";
-import { customColors, getShadow } from "@/modules/mui/theme/constants";
-import { Box, Container, Grid, Stack, Typography } from "@mui/material";
+import { Container, Grid, Stack, Typography } from "@mui/material";
 
 export const dynamic = "force-dynamic";
 
@@ -32,23 +32,13 @@ export default async function BlogIndex() {
       component="main"
       sx={{
         minHeight: "100vh",
-        backgroundColor: customColors.dark.main,
-        backgroundImage: `linear-gradient(180deg, ${customColors.dark.main}, ${customColors.lessDark.main})`,
+        bgcolor: "background.default",
         py: { xs: 6, md: 10 },
       }}
     >
       <Container maxWidth="lg">
-        <Box
-          sx={{
-            backgroundImage: `linear-gradient(135deg, ${customColors.lessDark.main}, ${customColors.orange.main})`,
-            borderRadius: 6,
-            p: { xs: 4, md: 6 },
-            boxShadow: getShadow("lg"),
-            color: "white",
-            textAlign: { xs: "center", md: "left" },
-          }}
-        >
-          <Typography component="h1" variant="h3" fontWeight={700} gutterBottom>
+        <Stack spacing={1.5} textAlign={{ xs: "center", md: "left" }}>
+          <Typography component="h1" variant="h3" fontWeight={700}>
             Insights from Tembo Tech Ventures
           </Typography>
           <Typography
@@ -58,7 +48,7 @@ export default async function BlogIndex() {
             Explore founder stories, product learnings, and the principles that
             guide how we build technology with purpose.
           </Typography>
-        </Box>
+        </Stack>
 
         {posts.length > 0 ? (
           <Grid container spacing={{ xs: 3, md: 4 }} mt={{ xs: 4, md: 6 }}>
@@ -69,26 +59,17 @@ export default async function BlogIndex() {
             ))}
           </Grid>
         ) : (
-          <Box
-            sx={{
-              mt: 6,
-              borderRadius: 4,
-              backgroundColor: "rgba(1, 61, 57, 0.65)",
-              border: `1px solid rgba(242, 141, 104, 0.35)`,
-              p: { xs: 4, md: 6 },
-              color: "white",
-              textAlign: "center",
-              boxShadow: getShadow("md"),
-            }}
-          >
-            <Typography variant="h5" fontWeight={600} gutterBottom>
-              Posts are on their way
-            </Typography>
-            <Typography variant="body1" color="rgba(255, 255, 255, 0.75)">
-              Check back soon for fresh thinking from the Tembo Tech Ventures
-              team.
-            </Typography>
-          </Box>
+          <Stack mt={{ xs: 4, md: 6 }}>
+            <Card component="section" style={{ textAlign: "center" }}>
+              <Typography variant="h5" fontWeight={600} gutterBottom>
+                Posts are on their way
+              </Typography>
+              <Typography variant="body1" color="text.secondary">
+                Check back soon for fresh thinking from the Tembo Tech Ventures
+                team.
+              </Typography>
+            </Card>
+          </Stack>
         )}
       </Container>
     </Stack>


### PR DESCRIPTION
## Summary
- flatten the blog index hero and switch post previews/empty state to the shared Card surface
- update blog teaser cards to use the homepage Card styling with consistent typography
- restyle individual blog posts to reuse the Card header while letting Markdown render directly on the page background

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03cfb8808832caa859d8db00be714