### PR TITLE
Add profile photo uploads 

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,7 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "@vitest/runner": "^4.1.5",
-        "drizzle-kit": "^0.31.10",
+        "drizzle-kit": "^0.31.4",
         "eslint": "^10.2.1",
         "eslint-plugin-astro": "^1.7.0",
         "typescript": "^5.8.0",

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,8 @@
     "zod": "^3.24.0"
   },
   "overrides": {
-    "vite": "^7"
+    "vite": "^7",
+    "kysely": "^0.28.14"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -45,7 +46,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitest/runner": "^4.1.5",
-    "drizzle-kit": "^0.31.10",
+    "drizzle-kit": "^0.31.4",
     "eslint": "^10.2.1",
     "eslint-plugin-astro": "^1.7.0",
     "typescript": "^5.8.0",

--- a/web/src/lib/avatar.test.ts
+++ b/web/src/lib/avatar.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { extractAvatarObjectKey, storeProfilePhoto } from "./avatar";
+
+function createMockImages() {
+  const transform = vi.fn().mockReturnValue({
+    output: vi.fn().mockResolvedValue({
+      response: vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "content-type": "image/webp" },
+        })
+      ),
+      contentType: vi.fn().mockResolvedValue("image/webp"),
+    }),
+  });
+
+  return {
+    info: vi.fn().mockResolvedValue({
+      format: "image/png",
+      fileSize: 1234,
+      width: 1800,
+      height: 1200,
+    }),
+    input: vi.fn().mockReturnValue({
+      transform,
+    }),
+    __transform: transform,
+  };
+}
+
+describe("avatar uploads", () => {
+  it("stores a resized avatar in R2 and removes the previous avatar", async () => {
+    const images = createMockImages();
+    const bucket = {
+      put: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    const file = new File([new Uint8Array([9, 8, 7])], "avatar.png", {
+      type: "image/png",
+    });
+
+    const result = await storeProfilePhoto(
+      {
+        BUCKET: bucket as never,
+        IMAGES: images as never,
+      },
+      {
+        userId: "user_123",
+        file,
+        previousImageUrl: "/api/avatar/avatars/user_123/old.webp",
+      }
+    );
+
+    expect(images.info).toHaveBeenCalledTimes(1);
+    expect(images.input).toHaveBeenCalledTimes(1);
+    expect(images.__transform).toHaveBeenCalledWith({
+      fit: "scale-down",
+      width: 1024,
+      height: 1024,
+    });
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+
+    const [storedKey, storedBlob, storedOptions] = bucket.put.mock.calls[0];
+    expect(storedKey).toMatch(/^avatars\/user_123\/.+\.webp$/);
+    expect(storedBlob).toBeInstanceOf(Blob);
+    expect(storedOptions).toEqual({
+      httpMetadata: {
+        contentType: "image/webp",
+      },
+    });
+    expect(bucket.delete).toHaveBeenCalledWith("avatars/user_123/old.webp");
+    expect(result.imageUrl).toMatch(/^\/api\/avatar\/avatars\/user_123\/.+\.webp$/);
+    expect(result.contentType).toBe("image/webp");
+    expect(extractAvatarObjectKey(result.imageUrl)).toMatch(
+      /^avatars\/user_123\/.+\.webp$/
+    );
+  });
+
+  it("rejects non-image uploads", async () => {
+    const images = createMockImages();
+    const bucket = {
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+    const file = new File([new Uint8Array([1, 2, 3])], "notes.txt", {
+      type: "text/plain",
+    });
+
+    await expect(
+      storeProfilePhoto(
+        {
+          BUCKET: bucket as never,
+          IMAGES: images as never,
+        },
+        {
+          userId: "user_123",
+          file,
+        }
+      )
+    ).rejects.toThrow("Please upload a PNG, JPG, GIF, or WebP image.");
+
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/avatar.ts
+++ b/web/src/lib/avatar.ts
@@ -1,0 +1,104 @@
+const AVATAR_ROUTE_PREFIX = "/api/avatar/";
+const AVATAR_OBJECT_PREFIX = "avatars";
+const AVATAR_MAX_DIMENSION = 1024;
+const AVATAR_OUTPUT_FORMAT = "image/webp" as const;
+const MAX_AVATAR_UPLOAD_SIZE = 5 * 1024 * 1024;
+
+type AvatarStorageEnv = Pick<Cloudflare.Env, "BUCKET" | "IMAGES">;
+
+export class AvatarUploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AvatarUploadError";
+  }
+}
+
+function assertImageFile(file: File) {
+  if (!file.size) {
+    throw new AvatarUploadError("Please choose an image to upload.");
+  }
+
+  if (file.size > MAX_AVATAR_UPLOAD_SIZE) {
+    throw new AvatarUploadError("Profile photos must be 5 MB or smaller.");
+  }
+
+  if (!file.type.startsWith("image/") || file.type === "image/svg+xml") {
+    throw new AvatarUploadError("Please upload a PNG, JPG, GIF, or WebP image.");
+  }
+}
+
+export function extractAvatarObjectKey(imageUrl?: string | null) {
+  if (!imageUrl) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(imageUrl, "https://ttv.local");
+
+    if (!parsed.pathname.startsWith(AVATAR_ROUTE_PREFIX)) {
+      return null;
+    }
+
+    return decodeURIComponent(parsed.pathname.slice(AVATAR_ROUTE_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+export async function storeProfilePhoto(
+  env: AvatarStorageEnv,
+  params: {
+    userId: string;
+    file: File;
+    previousImageUrl?: string | null;
+  }
+) {
+  assertImageFile(params.file);
+
+  const uploadBytes = await params.file.arrayBuffer();
+  const uploadBlob = new Blob([uploadBytes], {
+    type: params.file.type || "application/octet-stream",
+  });
+
+  try {
+    await env.IMAGES.info(uploadBlob.stream());
+  } catch {
+    throw new AvatarUploadError("Please upload a valid image file.");
+  }
+
+  const transformedImage = await env.IMAGES
+    .input(uploadBlob.stream())
+    .transform({
+      fit: "scale-down",
+      width: AVATAR_MAX_DIMENSION,
+      height: AVATAR_MAX_DIMENSION,
+    })
+    .output({
+      format: AVATAR_OUTPUT_FORMAT,
+      quality: 85,
+    });
+
+  const response = await transformedImage.response();
+  const contentType =
+    response.headers.get("content-type") ??
+    (await transformedImage.contentType());
+  const objectKey = `${AVATAR_OBJECT_PREFIX}/${params.userId}/${crypto.randomUUID()}.webp`;
+  const storedBlob = await response.blob();
+
+  await env.BUCKET.put(objectKey, storedBlob, {
+    httpMetadata: {
+      contentType,
+    },
+  });
+
+  const previousObjectKey = extractAvatarObjectKey(params.previousImageUrl);
+  if (previousObjectKey && previousObjectKey !== objectKey) {
+    await env.BUCKET.delete(previousObjectKey);
+  }
+
+  return {
+    contentType,
+    imageUrl: `${AVATAR_ROUTE_PREFIX}${objectKey}`,
+    objectKey,
+  };
+}

--- a/web/src/pages/api/avatar/[...key].ts
+++ b/web/src/pages/api/avatar/[...key].ts
@@ -1,0 +1,24 @@
+import { env } from "cloudflare:workers";
+
+export async function GET({ params }: { params: { key?: string | string[] } }) {
+  const requestedKey = Array.isArray(params.key)
+    ? params.key.join("/")
+    : params.key;
+
+  if (!requestedKey || !requestedKey.startsWith("avatars/")) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const object = await env.BUCKET.get(requestedKey);
+  if (!object) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const headers = new Headers();
+  object.writeHttpMetadata(headers);
+  headers.set("cache-control", "public, max-age=31536000, immutable");
+
+  return new Response(object.body, {
+    headers,
+  });
+}

--- a/web/src/pages/dashboard/profile.astro
+++ b/web/src/pages/dashboard/profile.astro
@@ -5,6 +5,7 @@ import { drizzle } from "drizzle-orm/d1";
 import * as schema from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
+import { AvatarUploadError, storeProfilePhoto } from "@/lib/avatar";
 
 const user = Astro.locals.user!;
 const db = drizzle(env.DB, { schema });
@@ -12,25 +13,52 @@ const db = drizzle(env.DB, { schema });
 let success = "";
 let error = "";
 
-// Handle POST — update user profile
+// Handle POST — update user profile or avatar
 if (Astro.request.method === "POST") {
   try {
     const formData = await Astro.request.formData();
-    const name = (formData.get("name") as string)?.trim();
+    const action = formData.get("action");
 
-    if (!name) {
-      error = "Name is required.";
-    } else {
+    if (action === "avatar") {
+      const avatarFile = formData.get("avatar");
+
+      if (!(avatarFile instanceof File)) {
+        throw new AvatarUploadError("Please choose an image to upload.");
+      }
+
+      const uploadedAvatar = await storeProfilePhoto(env, {
+        userId: user.id,
+        file: avatarFile,
+        previousImageUrl: user.image,
+      });
+
       await db
         .update(schema.user)
-        .set({ name })
+        .set({ image: uploadedAvatar.imageUrl })
         .where(eq(schema.user.id, user.id));
 
-      user.name = name;
-      success = "Profile updated successfully!";
+      user.image = uploadedAvatar.imageUrl;
+      success = "Profile photo updated successfully!";
+    } else {
+      const name = (formData.get("name") as string)?.trim();
+
+      if (!name) {
+        error = "Name is required.";
+      } else {
+        await db
+          .update(schema.user)
+          .set({ name })
+          .where(eq(schema.user.id, user.id));
+
+        user.name = name;
+        success = "Profile updated successfully!";
+      }
     }
-  } catch (_e) {
-    error = "Something went wrong. Please try again.";
+  } catch (e) {
+    error =
+      e instanceof AvatarUploadError
+        ? e.message
+        : "Something went wrong. Please try again.";
   }
 }
 ---
@@ -75,6 +103,31 @@ if (Astro.request.method === "POST") {
             <p class="text-lg font-semibold text-white">{user.name}</p>
             <p class="text-sm text-white/60">{user.email}</p>
           </div>
+          <form method="POST" enctype="multipart/form-data" class="w-full space-y-3">
+            <input type="hidden" name="action" value="avatar" />
+            <div class="flex flex-col gap-1.5 text-left">
+              <label for="avatar" class="text-sm font-medium text-white/90">
+                Profile photo
+              </label>
+              <input
+                id="avatar"
+                name="avatar"
+                type="file"
+                accept="image/*"
+                required
+                class="block w-full cursor-pointer rounded-md border border-teal bg-dark/50 px-3 py-2 text-sm text-white file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:font-medium file:text-dark hover:file:bg-primary/90 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+              <p class="text-xs text-white/40">
+                Upload a PNG, JPG, GIF, or WebP image. Files are resized to a maximum of 1024x1024 before storage.
+              </p>
+            </div>
+            <button
+              type="submit"
+              class="inline-flex w-full items-center justify-center rounded-md bg-primary px-6 py-2 font-medium text-dark hover:bg-primary/90 transition-colors"
+            >
+              Upload Photo
+            </button>
+          </form>
         </div>
       </Card>
 
@@ -82,6 +135,7 @@ if (Astro.request.method === "POST") {
       <Card class="lg:col-span-2">
         <h3 class="mb-4 text-lg font-semibold text-white">Edit Profile</h3>
         <form method="POST" class="space-y-4">
+          <input type="hidden" name="action" value="profile" />
           <div class="flex flex-col gap-1.5">
             <label for="name" class="text-sm font-medium text-white/90">
               Name <span class="text-primary">*</span>

--- a/web/worker-configuration.d.ts
+++ b/web/worker-configuration.d.ts
@@ -5,6 +5,7 @@ declare namespace Cloudflare {
 	interface Env {
 		BUCKET: R2Bucket;
 		DB: D1Database;
+		IMAGES: ImagesBinding;
 		BETTER_AUTH_URL: string;
 		BETTER_AUTH_SECRET: string;
 		GITHUB_CLIENT_ID: string;

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -5,6 +5,10 @@
   "compatibility_flags": ["nodejs_compat"],
   "main": "@astrojs/cloudflare/entrypoints/server",
 
+  "images": {
+    "binding": "IMAGES"
+  },
+
   // D1 Database
   "d1_databases": [
     {


### PR DESCRIPTION
  ## Summary

  Add a profile photo upload flow for dashboard users. Uploaded images are resized to a maximum of 1024x1024, stored in R2, and then served back through the app.

  ## Changes

  - Added a reusable avatar upload helper
  - Added a route to serve avatars from R2
  - Added profile page upload UI and server handling
  - Added Cloudflare Images binding for resizing
  - Added tests for upload, validation, and cleanup

  ## Test plan

  - [x] `npm test` passes
  - [x] Manual testing: uploaded an image and confirmed the avatar URL is stored and rendered
  - [ ] `npm run lint` passes

  ## Notes

  The feature reuses the existing `user.image` field instead of adding a new avatar column.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Avatar upload: Update your profile photo from the profile page with validation and improved feedback.
  * Image optimization & delivery: Uploaded avatars are processed into a web-friendly format and served via a dedicated API with long-term caching.
* **Tests**
  * Added automated coverage for avatar upload validation, processing, storage, and URL/content-type behavior.
* **Chores**
  * Updated image tooling/build settings to align dependency constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->